### PR TITLE
List staged and working tree files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-git-changedfiles",
-    "version": "0.0.2",
-    "description": "Grunt plugin to generate a list of the files that have changed in your Git working tree.",
+    "version": "0.0.3",
+    "description": "Grunt plugin to generate a list of the files that have changed since the last commit.",
     "main": "index.js",
     "scripts": {
         "test": "grunt test"
@@ -45,6 +45,10 @@
         {
             "name" : "Richard Marr"
             , "email" : "richard.marr@gmail.com"
+        },
+        {
+          "name" : "Todd Treece",
+          "email" : "toddtreece@gmail.com"
         }
     ]
 }

--- a/tasks/changedfiles.js
+++ b/tasks/changedfiles.js
@@ -8,11 +8,11 @@ module.exports = function (grunt) {
         var done = this.async();
         grunt.util.spawn({
             cmd: 'git',
-            args: ['diff', '--name-only', '--diff-filter=ACM'] // '--cached', 
+            args: ['diff', 'HEAD', '--name-only', '--diff-filter=ACM'] // staged and working tree files
         }, function(error, result){
-            
+
             var changedFiles = String(result).split(grunt.util.linefeed);
-            
+
             grunt.config.set('git.changed', changedFiles);
 
             grunt.verbose.writeln("changed files:           " + grunt.config.process('<%= git.changed %>').join(', '));


### PR DESCRIPTION
I am using this plugin in a pre-commit git hook, and using it to pass files to jshint.  Because files are staged when the pre-commit hook runs, they are skipped by `git diff`.  This pull request modifies the `git diff` call to include both staged _and_ working tree files in the changed file list.
